### PR TITLE
Allow files to load if extension is omitted

### DIFF
--- a/lyncs_io/base.py
+++ b/lyncs_io/base.py
@@ -11,6 +11,7 @@ __all__ = [
 ]
 
 from .formats import formats
+from .utils import find_file
 
 
 def load(filename, format=None, **kwargs):
@@ -28,25 +29,7 @@ def load(filename, format=None, **kwargs):
         One of the implemented formats. See documentation for more details.
     """
 
-    if filename:
-        from os import listdir
-        from os.path import dirname, abspath, splitext
-
-        abs_path = abspath(filename) # Absolute path of filename
-        ext = splitext(filename)[1] # Get the extension of the filename
-        parent_dir_path = dirname(abs_path) # Name of filename's parent directory
-
-        if not ext: 
-            dir_files = listdir(parent_dir_path)
-            if filename not in dir_files:
-                # A list with files matching the following pattern: filename.*
-                possible_files = [f for f in dir_files if splitext(f)[0] == filename]
-
-                # If only one such file exists, load that.
-                if len(possible_files) == 1:
-                    filename = possible_files[0]
-                else:
-                    raise Exception(f'More than one {filename}.* exist')
+    filename = find_file(filename)
 
     return formats.get_format(format, filename=filename).load(filename, **kwargs)
 
@@ -67,6 +50,8 @@ def head(filename, format=None, **kwargs):
         Additional options for performing the reading. The list of options depends
         on the format.
     """
+
+    filename = find_file(filename)
 
     return formats.get_format(format, filename=filename).head(filename, **kwargs)
 

--- a/lyncs_io/base.py
+++ b/lyncs_io/base.py
@@ -28,6 +28,26 @@ def load(filename, format=None, **kwargs):
         One of the implemented formats. See documentation for more details.
     """
 
+    if filename:
+        from os import listdir
+        from os.path import dirname, abspath, splitext
+
+        abs_path = abspath(filename) # Absolute path of filename
+        ext = splitext(filename)[1] # Get the extension of the filename
+        parent_dir_path = dirname(abs_path) # Name of filename's parent directory
+
+        if not ext: 
+            dir_files = listdir(parent_dir_path)
+            if filename not in dir_files:
+                # A list with files matching the following pattern: filename.*
+                possible_files = [f for f in dir_files if splitext(f)[0] == filename]
+
+                # If only one such file exists, load that.
+                if len(possible_files) == 1:
+                    filename = possible_files[0]
+                else:
+                    raise Exception(f'More than one {filename}.* exist')
+
     return formats.get_format(format, filename=filename).load(filename, **kwargs)
 
 

--- a/lyncs_io/utils.py
+++ b/lyncs_io/utils.py
@@ -7,6 +7,37 @@ from io import IOBase, FileIO
 from pathlib import Path
 
 
+def find_file(filename):
+    """
+    Finds a file in the directory that has the same name
+    as the parameter <filename>. If the file does not exist,
+    the directory is searched for <filename.*> instead, and if
+    only one match is found, that particular filename is returned.
+
+    """
+
+    from os import listdir
+    from os.path import dirname, abspath, splitext
+
+    abs_path = abspath(filename)  # Absolute path of filename
+    parent_dir_path = dirname(abs_path)  # Name of filename's parent directory
+
+    if not filename in listdir(parent_dir_path):
+        # A list with files matching the following pattern: filename.*
+        possible_files = [f for f in listdir(
+            parent_dir_path) if splitext(f)[0] == filename]
+
+        # If only one such file exists, load that.
+        if len(possible_files) == 1:
+            return possible_files[0]
+        elif len(possible_files) > 1:
+            raise Exception(f'More than one {filename}.* exist')
+        else:
+            raise Exception(f'No such file: {filename}, {filename}.*')
+    else:
+        return filename
+
+
 def swap(fnc):
     "Returns a wrapper that swaps the first two arguments of the function"
     return wraps(fnc)(


### PR DESCRIPTION
When loading a file with no extension, the directory is searched for a file with the same filename but with an extension. If only one is found, load - otherwise, raise exception.

New functionality seems to work correctly but no tests have been run yet.